### PR TITLE
[개발] 사용자 포인트 충전 비관락 구현

### DIFF
--- a/src/domain/repository/User.repository.interface.ts
+++ b/src/domain/repository/User.repository.interface.ts
@@ -5,7 +5,10 @@ import { PointTransactionTypeEnum } from "../../enum/PointTransactionType.enum";
 import { User } from "../User.domain";
 
 export interface UserRepositoryInterface {
-  findByUuid(uuid: string): Promise<User>;
+  findByUuid(
+    uuid: string,
+    transactionalEntityManager: EntityManager,
+  ): Promise<User>;
   createWaitingQueue(uuid: string): Promise<User>;
   updatePoint(
     uuid: string,

--- a/src/domain/repository/User.repository.interface.ts
+++ b/src/domain/repository/User.repository.interface.ts
@@ -7,7 +7,7 @@ import { User } from "../User.domain";
 export interface UserRepositoryInterface {
   findByUuid(
     uuid: string,
-    transactionalEntityManager: EntityManager,
+    transactionalEntityManager?: EntityManager,
   ): Promise<User>;
   createWaitingQueue(uuid: string): Promise<User>;
   updatePoint(

--- a/src/domain/service/User.service.ts
+++ b/src/domain/service/User.service.ts
@@ -14,8 +14,14 @@ export class UserService {
     private readonly userRepositoryInterface: UserRepositoryInterface,
   ) {}
 
-  async findByUuid(uuid: string): Promise<User | undefined> {
-    const user = await this.userRepositoryInterface.findByUuid(uuid);
+  async findByUuid(
+    uuid: string,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<User | undefined> {
+    const user = await this.userRepositoryInterface.findByUuid(
+      uuid,
+      transactionalEntityManager,
+    );
     if (!user) {
       throw new Error(UserErrorCodeEnum.존재하지_않는_유저.message);
     }

--- a/src/infrastructure/User.repository.impl.ts
+++ b/src/infrastructure/User.repository.impl.ts
@@ -32,7 +32,7 @@ export class UserRepositoryImpl implements UserRepositoryInterface {
           where: {
             uuid,
           },
-          lock: { mode: "pessimistic_read" },
+          lock: { mode: "pessimistic_write" },
         }),
       );
     }

--- a/src/test/integration/presentation/User.controller.int.spec.ts
+++ b/src/test/integration/presentation/User.controller.int.spec.ts
@@ -1,4 +1,4 @@
-import { Repository } from "typeorm";
+import { DataSource, Repository } from "typeorm";
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken, TypeOrmModule } from "@nestjs/typeorm";
 
@@ -20,25 +20,34 @@ describe("User Controller integration test", () => {
   let userController: UserController;
   let userRepository: Repository<UserEntity>;
   let userPointLogRepository: Repository<UserPointLogEntity>;
+  let dataSource: DataSource;
 
   beforeAll(async () => {
+    dataSource = new DataSource({
+      type: "mysql",
+      host: "localhost",
+      port: 3306,
+      username: "user",
+      password: "123",
+      database: "concert",
+      synchronize: true,
+      dropSchema: true,
+      entities: [
+        UserEntity,
+        UserPointLogEntity,
+        UserQueueEntity,
+        ReservationTicketEntity,
+        SeatEntity,
+        PerformanceEntity,
+        ConcertEntity,
+        OrderTicketEntity,
+      ],
+    });
+    await dataSource.initialize();
+
     const module: TestingModule = await Test.createTestingModule({
       imports: [
-        TypeOrmModule.forRoot({
-          type: "sqlite",
-          database: ":memory:",
-          synchronize: true,
-          entities: [
-            UserEntity,
-            UserPointLogEntity,
-            UserQueueEntity,
-            ReservationTicketEntity,
-            SeatEntity,
-            PerformanceEntity,
-            ConcertEntity,
-            OrderTicketEntity,
-          ],
-        }),
+        TypeOrmModule.forRoot(dataSource.options),
         TypeOrmModule.forFeature([
           UserEntity,
           UserPointLogEntity,
@@ -70,19 +79,27 @@ describe("User Controller integration test", () => {
     );
   });
 
-  beforeEach(async () => {
-    // user setting
-    const userEntity = new UserEntity();
-    userEntity.uuid = "0001";
-    userEntity.point = 1000;
-    userRepository.insert(userEntity);
-  });
-
-  afterEach(async () => {
-    await Promise.all([userRepository.clear(), userPointLogRepository.clear()]);
+  afterAll(async () => {
+    await dataSource.destroy();
   });
 
   describe("chargeUserPoint: 유저 포인트를 충전한다.", () => {
+    beforeEach(async () => {
+      // user setting
+      const userEntity = new UserEntity();
+      userEntity.uuid = "0001";
+      userEntity.point = 1000;
+      userRepository.insert(userEntity);
+    });
+
+    afterEach(async () => {
+      await Promise.all([
+        userRepository.clear(),
+        userPointLogRepository.clear(),
+        // dataSource.destroy(),
+      ]);
+    });
+
     test("정상요청, 정상적으로 포인트가 충전된다.", async () => {
       //given
       const uuid = "0001";
@@ -92,6 +109,58 @@ describe("User Controller integration test", () => {
       const response = await userController.chargeUserPoint(uuid, { amount });
       //then
       expect(response.point).toBe(userBeforeUsePoint.point + amount);
+    });
+    // 락 적용 전
+    // test("[락 적용 전] 동시성 테스트, 포인트 충전 여러 요청 시 모두 성공하고 한 요청 건에 대해서만 업데이트 된다.", async () => {
+    //   //given
+    //   const uuid = "0001";
+    //   const amount = 200;
+    //   const userBeforeUsePoint = await userController.findUserPoint(uuid);
+    //   //when
+    //   await Promise.all([
+    //     userController.chargeUserPoint(uuid, { amount }),
+    //     userController.chargeUserPoint(uuid, { amount }),
+    //     userController.chargeUserPoint(uuid, { amount }),
+    //     userController.chargeUserPoint(uuid, { amount }),
+    //   ]);
+
+    //   const userAfterChargePoint = await userController.findUserPoint(uuid);
+    //   //then
+    //   expect(userAfterChargePoint.point).toBe(
+    //     userBeforeUsePoint.point + amount,
+    //   );
+    // });
+    test("[비관적 읽기 잠금] 동시성 테스트, 포인트 충전 여러 요청 시 1개의 요청을 제외하고 실패한다.", async () => {
+      //given
+      const uuid = "0001";
+      const amount = 200;
+      //when
+      const requests = [
+        userController.chargeUserPoint(uuid, { amount }),
+        userController.chargeUserPoint(uuid, { amount: 3000 }),
+        userController.chargeUserPoint(uuid, { amount: 4000 }),
+        userController.chargeUserPoint(uuid, { amount: 5000 }),
+      ];
+      const results = await Promise.allSettled(requests);
+
+      // then
+      let successfulRequests = 0;
+      let failedRequests = 0;
+
+      results.forEach((result) => {
+        if (result.status === "fulfilled") {
+          successfulRequests++;
+        } else if (result.status === "rejected") {
+          expect(result.reason.message).toContain(
+            "Deadlock found when trying to get lock; try restarting transaction",
+          );
+          failedRequests++;
+        }
+      });
+
+      // 최종 결과 확인
+      expect(successfulRequests).toBeGreaterThanOrEqual(1);
+      expect(failedRequests).toBeGreaterThanOrEqual(1);
     });
   });
 });


### PR DESCRIPTION
🔎 작업 내용

- 사용자 포인트 차감 API 비관적 읽기 잠금 / 비관적 쓰기 잠금 구현 하였습니다.

 **비관적 읽기잠금**  `pessimistic_read`
- 데이터를 읽으면서 다른 트랜잭션이 해당 데이터를 수정하지 못하도록 잠금.(다른 트랙잭션이 읽기는 가능)
- 첫 조회 findByUuid 에서 `pessimistic_read` lock
<img width="650" alt="사용자포인트-비관적읽기락" src="https://github.com/user-attachments/assets/611bb820-12fd-4d58-ba24-a2532b215adf">

_읽기는 가능하나 쓰기에서 에러가 나는 모습_
<img width="870" alt="사용자포인트-비관적읽기락2" src="https://github.com/user-attachments/assets/f866d40d-78b1-41ea-9eca-29a1c732272e">

**비관적 쓰기 잠금** `pessimistic_write`
    - 데이터를 읽는 동시에 해당 데이터에 대한 독점적인 쓰기 잠금을 설정 (다른 트랜잭션이 데이터에 대한 읽기 및 쓰기 작업을 할 수 없음)
    - 첫 조회 findByUuid 에서 `pessimistic_write` lock
    
<img width="1137" alt="사용자포인트-비관적쓰기락" src="https://github.com/user-attachments/assets/5381671a-18a2-46df-b25b-4a60b57c25bb">

