### PR TITLE
[개발] DB Lock 을 활용한 동시성 제어 방식 구현

### DIFF
--- a/src/application/Concert.facade.ts
+++ b/src/application/Concert.facade.ts
@@ -45,33 +45,34 @@ export class ConcertFacade {
   async reservation(
     reservationTicket: ReservationTicket,
   ): Promise<ReservationTicket> {
-    const [seat, user] = await Promise.all([
-      this.concertService.findSeatById(reservationTicket.seatId),
-      this.userService.findByUuid(reservationTicket.userUuid),
-    ]);
-    // 공연 상태 확인
-    if (!seat.performance.isTicketAvailableDate()) {
-      throw new Error(ConcertErrorCodeEnum.예약_가능한_시간이_지남.message);
-    }
-    // 사용자 잔액 확인
-    if (seat.price > user.point) {
-      throw new Error(ConcertErrorCodeEnum.잔액부족.message);
-    }
-
-    const amount = user.point - seat.price;
-
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();
     const manager = queryRunner.manager;
 
     try {
+      const [seat, user] = await Promise.all([
+        this.concertService.findSeatById(reservationTicket.seatId, manager),
+        this.userService.findByUuid(reservationTicket.userUuid, manager),
+      ]);
+      // 공연 상태 확인
+      if (!seat.performance.isTicketAvailableDate()) {
+        throw new Error(ConcertErrorCodeEnum.예약_가능한_시간이_지남.message);
+      }
+      // 사용자 잔액 확인
+      if (seat.price > user.point) {
+        throw new Error(ConcertErrorCodeEnum.잔액부족.message);
+      }
+
+      const amount = user.point - seat.price;
+
       const [ticket] = await Promise.all([
         this.concertService.reservation(reservationTicket, manager),
-        this.concertService.activeSeat(seat),
+        this.concertService.activeSeat(seat, manager),
         this.userService.updatePoint(
           reservationTicket.userUuid,
           amount,
+          null,
           manager,
         ),
         this.userService.insertPointHistory(
@@ -81,6 +82,8 @@ export class ConcertFacade {
           manager,
         ),
       ]);
+
+      await queryRunner.commitTransaction();
 
       return ticket;
     } catch (error) {

--- a/src/application/User.facade.ts
+++ b/src/application/User.facade.ts
@@ -1,10 +1,16 @@
+import { DataSource } from "typeorm";
 import { Injectable } from "@nestjs/common";
+
 import { UserService } from "../domain/service/User.service";
 import { PointTransactionTypeEnum } from "../enum/PointTransactionType.enum";
+import { UserErrorCodeEnum } from "../enum/UserErrorCode.enum";
 
 @Injectable()
 export class UserFacade {
-  constructor(private readonly userService: UserService) {}
+  constructor(
+    private readonly userService: UserService,
+    private readonly dataSource: DataSource,
+  ) {}
 
   async checkUserActivation(uuid: string): Promise<boolean> {
     const user = await this.userService.findByUuid(uuid);
@@ -22,14 +28,34 @@ export class UserFacade {
     const user = await this.userService.findByUuid(uuid);
     const point = user.point + amount;
 
-    await Promise.all([
-      this.userService.updatePoint(uuid, point),
-      this.userService.insertPointHistory(
-        uuid,
-        point,
-        PointTransactionTypeEnum.충전,
-      ),
-    ]);
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    const manager = queryRunner.manager;
+
+    try {
+      const [userAfterSave] = await Promise.all([
+        this.userService.updatePoint(uuid, point, user.version, manager),
+        this.userService.insertPointHistory(
+          uuid,
+          point,
+          PointTransactionTypeEnum.충전,
+          manager,
+        ),
+      ]);
+      if (user.version + 1 !== userAfterSave.version) {
+        throw new Error(UserErrorCodeEnum.동시성_이슈.message);
+      }
+
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      console.log(error);
+      await queryRunner.rollbackTransaction();
+
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
 
     return point;
   }

--- a/src/domain/Performance.domain.ts
+++ b/src/domain/Performance.domain.ts
@@ -28,10 +28,6 @@ export class Performance {
     return this._seatList.filter((seat) => !seat.isReserved);
   }
 
-  public getSeatInfo(seatId: number): Seat {
-    return this.seatList.find(({ id }) => id === seatId);
-  }
-
   public isTicketAvailableDate(): boolean {
     const currentDate = new Date();
 

--- a/src/domain/User.domain.ts
+++ b/src/domain/User.domain.ts
@@ -4,11 +4,18 @@ import { WaitingQueue } from "./WaitingQueue.domain";
 export class User {
   private readonly _uuid: string;
   private readonly _point: number;
+  private readonly _version: number;
   private readonly _waitingQueue: WaitingQueue;
 
-  constructor(uuid?: string, point?: number, waitingQueue?: WaitingQueue) {
+  constructor(
+    uuid?: string,
+    point?: number,
+    version?: number,
+    waitingQueue?: WaitingQueue,
+  ) {
     this._uuid = uuid;
     this._point = point;
+    this._version = version;
     this._waitingQueue = waitingQueue;
   }
 
@@ -22,6 +29,10 @@ export class User {
 
   get uuid(): string {
     return this._uuid;
+  }
+
+  get version(): number {
+    return this._version;
   }
 
   get point(): number {

--- a/src/domain/repository/Concert.repository.interface.ts
+++ b/src/domain/repository/Concert.repository.interface.ts
@@ -8,8 +8,14 @@ export interface ConcertRepositoryInterface {
   findAll(): Promise<Concert[]>;
   findById(concertId: number): Promise<Concert>;
   findBySeatId(seatId: number): Promise<Concert>;
-  findSeatById(seatId: number): Promise<Seat>;
-  updateSeat(seat: Seat): Promise<Seat>;
+  findSeatById(
+    seatId: number,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<Seat>;
+  updateSeat(
+    seat: Seat,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<Seat>;
   saveReservationTicket(
     reservationTicket: ReservationTicket,
     transactionalEntityManager?: EntityManager,

--- a/src/domain/repository/User.repository.interface.ts
+++ b/src/domain/repository/User.repository.interface.ts
@@ -9,8 +9,9 @@ export interface UserRepositoryInterface {
   createWaitingQueue(uuid: string): Promise<User>;
   updatePoint(
     uuid: string,
-    amount: number,
-    transactionalEntityManager?: EntityManager,
+    point: number,
+    version: number,
+    transactionalEntityManager: EntityManager,
   ): Promise<User>;
   insertPointHistory(
     uuid: string,

--- a/src/domain/repository/User.repository.interface.ts
+++ b/src/domain/repository/User.repository.interface.ts
@@ -5,7 +5,10 @@ import { PointTransactionTypeEnum } from "../../enum/PointTransactionType.enum";
 import { User } from "../User.domain";
 
 export interface UserRepositoryInterface {
-  findByUuid(uuid: string): Promise<User>;
+  findByUuid(
+    uuid: string,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<User>;
   createWaitingQueue(uuid: string): Promise<User>;
   updatePoint(
     uuid: string,

--- a/src/domain/service/Concert.service.ts
+++ b/src/domain/service/Concert.service.ts
@@ -38,8 +38,14 @@ export class ConcertService {
     return concert;
   }
 
-  async findSeatById(seatId: number): Promise<Seat> {
-    const seat = await this.concertRepositoryInterface.findSeatById(seatId);
+  async findSeatById(
+    seatId: number,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<Seat> {
+    const seat = await this.concertRepositoryInterface.findSeatById(
+      seatId,
+      transactionalEntityManager,
+    );
     if (!seat) {
       throw new Error(ConcertErrorCodeEnum.존재하지_않는_좌석_정보.message);
     }
@@ -47,10 +53,16 @@ export class ConcertService {
     return seat;
   }
 
-  activeSeat(seat: Seat): Promise<Seat> {
+  activeSeat(
+    seat: Seat,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<Seat> {
     seat.isReserved = true;
 
-    return this.concertRepositoryInterface.updateSeat(seat);
+    return this.concertRepositoryInterface.updateSeat(
+      seat,
+      transactionalEntityManager,
+    );
   }
 
   reservation(

--- a/src/domain/service/User.service.ts
+++ b/src/domain/service/User.service.ts
@@ -30,11 +30,13 @@ export class UserService {
   updatePoint(
     uuid: string,
     amount: number,
+    version: number,
     transactionalEntityManager?: EntityManager,
   ): Promise<User> {
     return this.userRepositoryInterface.updatePoint(
       uuid,
       amount,
+      version,
       transactionalEntityManager,
     );
   }

--- a/src/domain/service/User.service.ts
+++ b/src/domain/service/User.service.ts
@@ -14,8 +14,14 @@ export class UserService {
     private readonly userRepositoryInterface: UserRepositoryInterface,
   ) {}
 
-  async findByUuid(uuid: string): Promise<User | undefined> {
-    const user = await this.userRepositoryInterface.findByUuid(uuid);
+  async findByUuid(
+    uuid: string,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<User | undefined> {
+    const user = await this.userRepositoryInterface.findByUuid(
+      uuid,
+      transactionalEntityManager,
+    );
     if (!user) {
       throw new Error(UserErrorCodeEnum.존재하지_않는_유저.message);
     }

--- a/src/enum/UserErrorCode.enum.ts
+++ b/src/enum/UserErrorCode.enum.ts
@@ -10,6 +10,10 @@ export class UserErrorCodeEnum extends ErrorCodeEnum {
     "이미 발급받은 토큰이 있습니다.",
     HttpStatus.BAD_REQUEST,
   );
+  static readonly 동시성_이슈 = new UserErrorCodeEnum(
+    "올바르지 않은 요청입니다.",
+    HttpStatus.BAD_REQUEST,
+  );
 
   constructor(message: string, httpCode: HttpStatus) {
     super(message, httpCode);

--- a/src/infrastructure/Concert.repository.impl.ts
+++ b/src/infrastructure/Concert.repository.impl.ts
@@ -66,17 +66,44 @@ export class ConcertRepositoryImpl implements ConcertRepositoryInterface {
     );
   }
 
-  async findSeatById(seatId: number): Promise<Seat> {
+  async findSeatById(
+    seatId: number,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<Seat> {
+    if (transactionalEntityManager) {
+      return ConcertMapper.mapToSeatDomain(
+        await transactionalEntityManager.getRepository(SeatEntity).findOne({
+          relations: { performance: true },
+          where: { id: seatId },
+          lock: { mode: "pessimistic_read" },
+        }),
+      );
+    }
+
     return ConcertMapper.mapToSeatDomain(
       await this.seatRepository.findOne({
         relations: { performance: true },
         where: { id: seatId },
-        lock: { mode: "pessimistic_read" },
       }),
     );
   }
 
-  async updateSeat(seat: Seat): Promise<Seat> {
+  async updateSeat(
+    seat: Seat,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<Seat> {
+    if (transactionalEntityManager) {
+      const seatEntity = transactionalEntityManager
+        .getRepository(SeatEntity)
+        .create(ConcertMapper.mapToSeatEntity(seat));
+
+      return ConcertMapper.mapToSeatDomain(
+        await transactionalEntityManager
+          .getRepository(SeatEntity)
+          .save(seatEntity),
+      );
+    }
+
     const seatEntity = this.seatRepository.create(
       ConcertMapper.mapToSeatEntity(seat),
     );
@@ -88,7 +115,7 @@ export class ConcertRepositoryImpl implements ConcertRepositoryInterface {
 
   async saveReservationTicket(
     reservationTicket: ReservationTicket,
-    transactionalEntityManager: EntityManager,
+    transactionalEntityManager?: EntityManager,
   ): Promise<ReservationTicket> {
     const reservationTicketEntity = this.reservationTicketRepository.create(
       ConcertMapper.mapToReservationEntity(reservationTicket),

--- a/src/infrastructure/User.repository.impl.ts
+++ b/src/infrastructure/User.repository.impl.ts
@@ -21,15 +21,29 @@ export class UserRepositoryImpl implements UserRepositoryInterface {
     private readonly userPointLogRepository: Repository<UserPointLogEntity>,
   ) {}
 
-  async findByUuid(uuid: string): Promise<User> {
-    const user = await this.userRepository.findOne({
-      relations: { userQueueList: true },
-      where: {
-        uuid,
-      },
-    });
+  async findByUuid(
+    uuid: string,
+    transactionalEntityManager?: EntityManager,
+  ): Promise<User> {
+    if (transactionalEntityManager) {
+      return UserMapper.mapToUserDomain(
+        await transactionalEntityManager.getRepository(UserEntity).findOne({
+          relations: { userQueueList: true },
+          where: {
+            uuid,
+          },
+        }),
+      );
+    }
 
-    return UserMapper.mapToUserDomain(user);
+    return UserMapper.mapToUserDomain(
+      await this.userRepository.findOne({
+        relations: { userQueueList: true },
+        where: {
+          uuid,
+        },
+      }),
+    );
   }
 
   createWaitingQueue(uuid: string) {

--- a/src/infrastructure/entity/User.entity.ts
+++ b/src/infrastructure/entity/User.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from "typeorm";
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  VersionColumn,
+} from "typeorm";
 import { UserQueueEntity } from "./UserQueue.entity";
 import { UserPointLogEntity } from "./UserPointLog.entity";
 import { ReservationTicketEntity } from "./ReservationTicket.entity";
@@ -10,6 +16,9 @@ export class UserEntity {
 
   @Column()
   point: number;
+
+  @VersionColumn()
+  version: number;
 
   @OneToMany(() => UserQueueEntity, (m) => m.user, {
     createForeignKeyConstraints: false,

--- a/src/mapper/Concert.mapper.ts
+++ b/src/mapper/Concert.mapper.ts
@@ -42,6 +42,7 @@ export class ConcertMapper {
       entity.seat_no,
       entity.price,
       entity.is_reserved,
+      this.mapToPerformanceDomain(entity.performance),
     );
   }
 

--- a/src/mapper/User.mapper.ts
+++ b/src/mapper/User.mapper.ts
@@ -10,6 +10,7 @@ export class UserMapper {
     return new User(
       entity.uuid,
       entity.point,
+      entity.version,
       WaitingQueueMapper.mapToWaitingQueueDomain(
         entity.userQueueList?.find(
           ({ status }) => status !== WaitingQueueStatusEnum.만료,

--- a/src/test/integration/presentation/Concert.controller.int.spec.ts
+++ b/src/test/integration/presentation/Concert.controller.int.spec.ts
@@ -1,6 +1,8 @@
 import { DataSource, Repository } from "typeorm";
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken, TypeOrmModule } from "@nestjs/typeorm";
+import { JwtService } from "@nestjs/jwt";
+import { INestApplication } from "@nestjs/common";
 
 import { UserAuth } from "../../../../libs/decorator/UserAuth";
 
@@ -25,9 +27,9 @@ import { PerformanceEntity } from "../../../infrastructure/entity/Performance.en
 import { ConcertEntity } from "../../../infrastructure/entity/Concert.entity";
 import { OrderTicketEntity } from "../../../infrastructure/entity/OrderTicket.entity";
 import { AuthFacade } from "../../../application/Auth.facade";
-import { JwtService } from "@nestjs/jwt";
 
 describe("Concert Controller integration test", () => {
+  let app: INestApplication;
   let concertController: ConcertController;
   let userRepository: Repository<UserEntity>;
   let concertRepository: Repository<ConcertEntity>;
@@ -56,6 +58,7 @@ describe("Concert Controller integration test", () => {
         ConcertEntity,
         OrderTicketEntity,
       ],
+      logging: true,
     });
     await dataSource.initialize();
 
@@ -103,6 +106,9 @@ describe("Concert Controller integration test", () => {
       })
       .compile();
 
+    app = module.createNestApplication();
+    await app.init();
+
     concertController = module.get<ConcertController>(ConcertController);
     userRepository = module.get<Repository<UserEntity>>(
       getRepositoryToken(UserEntity),
@@ -123,13 +129,23 @@ describe("Concert Controller integration test", () => {
 
   afterAll(async () => {
     await dataSource.destroy();
+    await app.close();
   });
 
   beforeEach(async () => {
     // user setting
-    const user = new UserEntity();
-    user.uuid = "0001";
-    user.point = 100000;
+    const user1 = new UserEntity();
+    user1.uuid = "0001";
+    user1.point = 100000;
+    const user2 = new UserEntity();
+    user2.uuid = "0002";
+    user2.point = 200000;
+    const user3 = new UserEntity();
+    user3.uuid = "0003";
+    user3.point = 300000;
+    const user4 = new UserEntity();
+    user4.uuid = "0004";
+    user4.point = 400000;
     // concert setting
     const concert = new ConcertEntity();
     concert.id = 1;
@@ -147,10 +163,11 @@ describe("Concert Controller integration test", () => {
     seat.id = 1;
     seat.performance_id = 1;
     seat.seat_no = 1;
+    seat.is_reserved = false;
     seat.price = 1000;
 
     await Promise.all([
-      userRepository.insert(user),
+      userRepository.insert([user1, user2, user3, user4]),
       concertRepository.insert(concert),
       performanceRepository.insert(performance),
       seatRepository.insert(seat),
@@ -163,27 +180,86 @@ describe("Concert Controller integration test", () => {
       concertRepository.clear(),
       performanceRepository.clear(),
       seatRepository.clear(),
+      reservationTicketRepository.clear(),
     ]);
   });
 
   describe("reservation: 콘서트 좌석을 예약한다.", () => {
-    test("정상요청, 콘서트가 예약된다.", async () => {
+    // test("정상요청, 콘서트가 예약된다.", async () => {
+    //   //given
+    //   const seatId = 2;
+    //   const userEntity = await userRepository.findOne({
+    //     where: { uuid: "0001" },
+    //   });
+    //   const user = UserMapper.mapToUserDomain(userEntity);
+    //   //when
+    //   const response = await concertController.reservation(
+    //     new ReservationConcertRequestDTO(seatId),
+    //     user,
+    //   );
+    //   const reservationTicket = await reservationTicketRepository.findOne({
+    //     where: { user_uuid: user.uuid, seat_id: seatId },
+    //   });
+    //   //then
+    //   expect(response.reservationTicketId).toBe(reservationTicket.id);
+    // });
+    test("비관적 읽기 잠금, 여러명이 동시 요청 했을 때 1명의 요청만 성공한다.", async () => {
       //given
+      // user setting
+      const userEntitis = await userRepository.find({
+        where: [
+          { uuid: "0001" },
+          { uuid: "0002" },
+          { uuid: "0003" },
+          { uuid: "0004" },
+        ],
+      });
+
       const seatId = 1;
-      const userEntity = await userRepository.findOne({
-        where: { uuid: "0001" },
-      });
-      const user = UserMapper.mapToUserDomain(userEntity);
       //when
-      const response = await concertController.reservation(
-        new ReservationConcertRequestDTO(seatId),
-        user,
-      );
-      const reservationTicket = await reservationTicketRepository.findOne({
-        where: { user_uuid: user.uuid, seat_id: seatId },
-      });
+      const requests = [
+        concertController.reservation(
+          new ReservationConcertRequestDTO(seatId),
+          UserMapper.mapToUserDomain(
+            userEntitis.find((user) => user.uuid === "0001"),
+          ),
+        ),
+        concertController.reservation(
+          new ReservationConcertRequestDTO(seatId),
+          UserMapper.mapToUserDomain(
+            userEntitis.find((user) => user.uuid === "0002"),
+          ),
+        ),
+        concertController.reservation(
+          new ReservationConcertRequestDTO(seatId),
+          UserMapper.mapToUserDomain(
+            userEntitis.find((user) => user.uuid === "0003"),
+          ),
+        ),
+        concertController.reservation(
+          new ReservationConcertRequestDTO(seatId),
+          UserMapper.mapToUserDomain(
+            userEntitis.find((user) => user.uuid === "0004"),
+          ),
+        ),
+      ];
+      const results = await Promise.allSettled(requests);
       //then
-      expect(response.reservationTicketId).toBe(reservationTicket.id);
+      let successfulRequests = 0;
+      let failedReqeust = 0;
+
+      results.forEach((result) => {
+        if (result.status === "fulfilled") {
+          successfulRequests++;
+        } else if (result.status === "rejected") {
+          expect(result.reason.message).toContain(
+            "Deadlock found when trying to get lock; try restarting transaction",
+          );
+          failedReqeust++;
+        }
+      });
+      expect(successfulRequests).toBe(1);
+      expect(failedReqeust).toBe(3);
     });
   });
 });


### PR DESCRIPTION
##  🔎 작업 내용

- DB Lock을 활용하여 동시성 제어가 필요한 로직에 대해 여러 Lock를 적용해보았습니다.
1. 사용자 포인트 충전 API
  - 낙관락: https://github.com/nueob/hhp-concert-ticketing/pull/4
  - 비관락: https://github.com/nueob/hhp-concert-ticketing/pull/5
2. 콘서트 예약 API
  - 낙관락: https://github.com/nueob/hhp-concert-ticketing/pull/6
  - 비관락: https://github.com/nueob/hhp-concert-ticketing/pull/8
  
## ➕ 동시성 제어

### 1. 사용자 포인트 충전 API `낙관락`
 |            |  시간  | 
 | ------- | ------- |
 |   공유락   |  5.769   |
|   배타락   |  5.487   | 
|   낙관락   |  5.745   | 

  사용자가 자의로 혹은 타의로 포인트 충전을 한번에 여러 번 요청 할 수 있습니다.
  
       1. 동시성 이슈를 클라이언트에서도 막을 수 있어 이슈가 상대적으로 적다는 점
           - 요청 반복 클릭 시 한번만 요청, 클라이언트에서 lock 제어 등
           
       2. 실제 포인트 충전에서 동시성 제어를 할 정도로 여러 반복 요청일 경우, 금액을 충전하기 위한 PG(혹은 카드사) API 호출에도 지장이 있을 것으로 DB에 동시성 이슈를 겪을 일이 적다는 점

       4. 낙관락으로 구현 시 트랜잭션 범위가 줄어 시간을 단축할 수 있다는 점

       5. 모든 충전 요청 성공이 사용자가 의도한게 아니지만 비관락으로 모든 충전 요청이 성공했을 경우, 
         충전된 요금에 대해 정책 상 환불이 어려울 수 있지만,

         모든 충전 요청 성공이 사용자가 의도한거지만 낙관락으로 모든 충전 요청이 성공하지 않았을 경우,
         충전 요청을 새로보냄으로 해결할 수 있다는 점

   위와 같은 네 가지 이유로 `낙관락`을 적용하게 되었습니다. 

[낙관락]
<img width="871" alt="사용자포인트-낙관락" src="https://github.com/user-attachments/assets/335f0842-3676-4417-b4b2-e56f010ec1cc">


[공유락] `pessimistic_read`
- 데이터를 읽으면서 다른 트랜잭션이 해당 데이터를 수정하지 못하도록 잠금.(다른 트랙잭션이 읽기는 가능)
- 첫 조회 findByUuid 에서 `pessimistic_read` lock
<img width="650" alt="사용자포인트-비관적읽기락" src="https://github.com/user-attachments/assets/611bb820-12fd-4d58-ba24-a2532b215adf">

[배타락] `pessimistic_write`
    - 데이터를 읽는 동시에 해당 데이터에 대한 독점적인 쓰기 잠금을 설정 (다른 트랜잭션이 데이터에 대한 읽기 및 쓰기 작업을 할 수 없음)
    - 첫 조회 findByUuid 에서 `pessimistic_write` lock
    
<img width="1137" alt="사용자포인트-비관적쓰기락" src="https://github.com/user-attachments/assets/5381671a-18a2-46df-b25b-4a60b57c25bb">
 
--------------------

### 2. 콘서트 예약 API `공유락`
 |            |  시간  | 
 | ------- | ------- |
 |   공유락   |  6.563   |
|   배타락   | 6.304   | 
|   낙관락   |  5.855   | 

여러 사용자가 한번에 하나의 좌석을 예약할 수 있습니다.

      1. 모든 요청이 성공하면 안되는 점
      2. 낙관락으로 구현하였을 때, 
      
          트랜잭션 A : 조회 -> 수정 -> 수정 이후 로직 실패 -> 롤백
          트랜잭션 B :             조회 -> 수정 후 version 유효성 검사 실패 -> 실패
   
          이와 같은 경우에서 트랜잭션 A가 수정 이후 로직에서 실패하여 롤백을 했는 데도 불구하고 트랜잭션 B 입장에서는 
          version이 업데이트 되어 실패처리를 하게 될 수 있다는 점
          
 위와 같은 이유로 `공유락`을 구현하게 되었습니다.
  
 하지만, `공유락`은 같이 첨부된 표와 같이 실행속도가 제일 느린 편입니다.
 또, 트랜잭션의 범위가 조회 이후 수정까지의 로직이 길게 되면 다른 트랜잭션이 무한정 대기를 해야하여 DB에 부하를 줄 수 있습니다.

 이와 같은 이유로 분산락으로 구현하게 된다면 기대하는 효과는 아래와 같습니다.

     1. 여러 트랜잭션이 대기하는 이슈가 없어 DB 부하가 줄어듭니다.
     2. 여러 요청 중 하나의 요청만 성공하게 됩니다.
     3. 레디스는 디스크 대신 메모리에 직접 접근하므로 DB락보다 빠릅니다.

[낙관락]
<img width="554" alt="image" src="https://github.com/user-attachments/assets/79f89e61-1cc5-4f54-ac21-74c5a94de434">

[공유락]
 - 좌석 정보을 가져오기 위한 첫 조회 findSeatById lock
<img width="593" alt="image" src="https://github.com/user-attachments/assets/2b24cfcb-b784-4ae2-93ef-fc278a9d85f2">

[배타락]
 - 좌석 정보을 가져오기 위한 첫 조회 findSeatById lock
<img width="549" alt="image" src="https://github.com/user-attachments/assets/37cbe32f-ca19-4b0a-a560-4ee10b77df1d">

## 🤔  회고
- 현재  Application 계층에서 트랜잭션을 걸고 있는 데, 트랜잭션이 필요한 로직을 Domain 계층으로 내려 Service에서 트랜잭션을 걸 수 있을 거 같습니다.

## ✋  질문
공유락에서 쓰기를 하려할 때 에러가 나는 데 혹시 로직이 잘못된건 지 아니면 정확한 에러인지 잘 모르겠습니다!
지금 예상으로는 트랜잭션 A가 조회/수정에서 락을 획득하고 트랜잭션 B가 조회에서 락을 획득한 후 수정에서 락을 획득하려할 때
데드락이 발생하는 거 같은 데 정확히 이해한 개념이 맞을까요?

<img width="870" alt="사용자포인트-비관적읽기락2" src="https://github.com/user-attachments/assets/f866d40d-78b1-41ea-9eca-29a1c732272e">